### PR TITLE
Fix CSRF session token error on plain HTTP deployments (#2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,11 @@ SECRET_KEY=""
 # WARNING: Never enable this in production!
 # Use "true" or "false" (case-insensitive).
 FLASK_DEBUG=false
+
+# Whether the session cookie requires HTTPS to be sent by the browser.
+# Keep "true" (default) if the app is served over HTTPS (e.g. behind a reverse proxy with TLS).
+# Set to "false" ONLY if you access the app over plain HTTP (e.g. http://server-ip:5000)
+# without TLS termination — otherwise you will get "Bad Request: The CSRF session token
+# is missing" errors when submitting forms.
+# Use "true" or "false" (case-insensitive).
+SESSION_COOKIE_SECURE=true

--- a/README.md
+++ b/README.md
@@ -246,6 +246,10 @@ The following variable is required in your `.env` file:
 
 * `FLASK_DEBUG`: Enable or disable Flask debug mode.
 
+* `SESSION_COOKIE_SECURE`: Whether the session cookie requires HTTPS to be sent by the browser. Defaults to `true`.
+
+> ⚠️ If you access the app over **plain HTTP** (e.g. `http://server-ip:5000`, with no reverse proxy/TLS in front of it), keep this default `true` and you will get a **"Bad Request: The CSRF session token is missing"** error when submitting forms, because browsers refuse to send secure cookies over an unencrypted connection. Set `SESSION_COOKIE_SECURE=false` in your `.env` to fix it in that case. Only disable it if you understand the security trade-off (the session cookie will then be sent unencrypted) — prefer adding HTTPS via a reverse proxy instead when possible.
+
 ---
 
 ## ⚠️ Security & Access Warning

--- a/app.py
+++ b/app.py
@@ -20,7 +20,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 app = Flask(__name__)
 app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY') or secrets.token_urlsafe(32)
 app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1)
-app.config['SESSION_COOKIE_SECURE'] = True
+app.config['SESSION_COOKIE_SECURE'] = os.getenv('SESSION_COOKIE_SECURE', 'true').lower() == 'true'
 app.config['SESSION_COOKIE_SAMESITE'] = 'Lax'
 app.config['SQLALCHEMY_DATABASE_URI'] = f"sqlite:///{os.path.join(app.instance_path, 'app.db')}"
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False


### PR DESCRIPTION
SESSION_COOKIE_SECURE was hardcoded to True, so the session cookie
(which Flask-WTF uses to store the CSRF token) was silently dropped
by browsers when the app is accessed over plain HTTP without a
TLS-terminating reverse proxy, causing "Bad Request: The CSRF
session token is missing" on form submits.

Make it configurable via the SESSION_COOKIE_SECURE env var
(default true, unchanged behavior for HTTPS/reverse-proxy setups),
and document when/why to set it to false in .env.example and README.